### PR TITLE
update RUN command for installing packages

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -2,12 +2,11 @@ ARG base_image
 
 FROM ${base_image}
 
-RUN apt update && apt upgrade -y
-RUN apt install \
-      curl \
-      bash \
-      jq \
-      gettext
+RUN apt update && apt install -y \
+ curl \
+ bash \
+ jq \
+ gettext
 
 COPY check /opt/resource/check
 COPY in    /opt/resource/in


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the RUN command to properly install packages

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing packages
